### PR TITLE
Add a missing #include directive

### DIFF
--- a/src/steps/geom/fwd.hpp
+++ b/src/steps/geom/fwd.hpp
@@ -1,6 +1,7 @@
 #ifndef STEPS_GEOM_FWD_HPP
 #define STEPS_GEOM_FWD_HPP
 
+#include <cstdint>
 #include <limits>
 #include <iosfwd>
 #include <type_traits>


### PR DESCRIPTION
- `<cstdint>` for `(u)int*_t`

Fixes failure to compile with GCC 13.

I only tested this by patching the [`python-steps` package in Fedora Linux](https://src.fedoraproject.org/rpms/python-steps), which is currently at 3.6.0, so it’s possible that more changes could needed for the current release, 4.0.1, to also compile successfully with GCC 13.